### PR TITLE
Fix static memory allocator compilation error

### DIFF
--- a/h/mem.hpp
+++ b/h/mem.hpp
@@ -51,8 +51,7 @@ class MemoryAllocator {
 
     size_t free_space_ = 0;
 
-    // Singleton instance pointer
-    static MemoryAllocator* instance_;
+    // No global singleton instance pointer; implemented with function-local static in getInstance()
 
     // Block info header size.
     static constexpr uint64 BLOCK_INFO_HEADER_SIZE = 5 * sizeof(uint64);

--- a/src/mem.cpp
+++ b/src/mem.cpp
@@ -1,8 +1,7 @@
 #include "../h/mem.hpp"
 
-MemoryAllocator* MemoryAllocator::instance_ = nullptr;
-
 MemoryAllocator *MemoryAllocator::getInstance() {
+    static MemoryAllocator* instance_ = nullptr;
     if (!instance_) {
         // Initialize the instance of the MemoryAllocator.
         instance_ = (MemoryAllocator*)HEAP_START_ADDR;


### PR DESCRIPTION
Fix `MemoryAllocator` header and implementation mismatches to resolve a compile error in the singleton `getInstance` method.

---
<a href="https://cursor.com/background-agent?bcId=bc-4089b61f-b8da-49fc-b8fb-0788eb06696c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4089b61f-b8da-49fc-b8fb-0788eb06696c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

