### PR TITLE
Debug cpp api body_exec execution

### DIFF
--- a/h/syscall_cpp.hpp
+++ b/h/syscall_cpp.hpp
@@ -10,14 +10,7 @@
 class Thread {
     public:
     Thread(void (*body)(void*), void* arg) : body(body), arg(arg) {}
-    virtual ~Thread() {
-        // TODO: Maybe check.
-        // This normally exits the currently running thread. I am not sure if 
-        // this will be called from a currently running thread though. In other
-        // words, if a different thread calls this thread's destructor, will
-        // that thread exit or will the thread this object is managing exit?
-        thread_exit();
-    }
+    virtual ~Thread() {}
     int start() {
         // TODO: Should we first initialize the thread without it starting?
         // The current implementation of TCB doesn't allow for this.
@@ -31,9 +24,7 @@ class Thread {
     static void dispatch() {
         thread_dispatch();
     }
-    static int sleep(time_t time) {
-        return 0;
-    }
+    static int sleep(time_t time) { return time_sleep(time); }
 
     protected:
     Thread() : myHandle(nullptr), body(nullptr), arg(nullptr) {}

--- a/src/riscv.cpp
+++ b/src/riscv.cpp
@@ -51,7 +51,7 @@ void Riscv::handleSupervisorTrap()
                 break;
             case SyscallCode::THREAD_CREATE: {
                 thread_t* handle = (thread_t*)a1;
-                *handle = (thread_t)TCB::createThread((void(*)(void*))a1, (void*)a2);
+                *handle = (thread_t)TCB::createThread((void(*)(void*))a2, (void*)a3);
                 if (!(*handle))
                     res = -1;
                 }


### PR DESCRIPTION
Fix `THREAD_CREATE` syscall argument mapping to enable C++ API thread execution and complete `Thread` class functionality.

The `body_exec` was not being invoked for C++ API threads because the `THREAD_CREATE` syscall in `riscv.cpp` was incorrectly mapping `start_routine` and `arg` to `a1` and `a2` instead of `a2` and `a3` respectively. This PR corrects the argument passing and also completes the `Thread` class by removing an erroneous `thread_exit()` call from the destructor and implementing `Thread::sleep`.

---
<a href="https://cursor.com/background-agent?bcId=bc-25d5fa60-8c8b-47ed-a555-e91b21592bd9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-25d5fa60-8c8b-47ed-a555-e91b21592bd9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

